### PR TITLE
Fixes

### DIFF
--- a/bitriseio/bitrise_yml.go
+++ b/bitriseio/bitrise_yml.go
@@ -5,19 +5,22 @@ import (
 	"net/http"
 )
 
-// BitriseYMLParams ...
-type BitriseYMLParams struct {
-	AppConfigDatastoreYAML string `json:"app_config_datastore_yaml,omitempty"`
-}
-
 // BitriseYMLURL ...
 func BitriseYMLURL(appSlug string) string {
 	return fmt.Sprintf(AppsServiceURL+"%s/bitrise.yml", appSlug)
 }
 
 // UploadBitriseYML ...
-func (s *AppService) UploadBitriseYML(params BitriseYMLParams) error {
-	req, err := s.client.newRequest(http.MethodPost, BitriseYMLURL(s.Slug), params)
+func (s *AppService) UploadBitriseYML(config string) error {
+	type BitriseYMLParams struct {
+		AppConfigDatastoreYAML string `json:"app_config_datastore_yaml"`
+	}
+
+	p := BitriseYMLParams{
+		AppConfigDatastoreYAML: config,
+	}
+
+	req, err := s.client.newRequest(http.MethodPost, BitriseYMLURL(s.Slug), p)
 	if err != nil {
 		return err
 	}

--- a/bitriseio/builds.go
+++ b/bitriseio/builds.go
@@ -5,25 +5,34 @@ import (
 	"net/http"
 )
 
-// BuildParams ...
-type BuildParams struct {
-	Branch     string `json:"branch,omitempty"`
-	WorkflowID string `json:"workflow_id,omitempty"`
-}
-
-// TriggerBuildParams ...
-type TriggerBuildParams struct {
-	BuildParams BuildParams `json:"build_params,omitempty"`
-}
-
 // TriggerBuildURL ...
 func TriggerBuildURL(appSlug string) string {
 	return fmt.Sprintf(AppsServiceURL+"%s/builds", appSlug)
 }
 
 // TriggerBuild ...
-func (s *AppService) TriggerBuild(params TriggerBuildParams) error {
-	req, err := s.client.newRequest(http.MethodPost, TriggerBuildURL(s.Slug), params)
+func (s *AppService) TriggerBuild(workflowID string) error {
+	type HookInfo struct {
+		Type string `json:"type"`
+	}
+	type BuildParams struct {
+		WorkflowID string `json:"workflow_id"`
+		Branch     string `json:"branch"`
+	}
+	type Params struct {
+		BuildParams BuildParams `json:"build_params"`
+		HookInfo    HookInfo    `json:"hook_info"`
+	}
+	p := Params{
+		BuildParams: BuildParams{
+			WorkflowID: workflowID,
+			Branch:     "master",
+		},
+		HookInfo: HookInfo{
+			Type: "bitrise",
+		},
+	}
+	req, err := s.client.newRequest(http.MethodPost, TriggerBuildURL(s.Slug), p)
 	if err != nil {
 		return err
 	}

--- a/bitriseio/client.go
+++ b/bitriseio/client.go
@@ -125,8 +125,8 @@ func checkResponse(r *http.Response) error {
 
 // ErrorResponse ...
 type ErrorResponse struct {
-	Status int    `json:"status"`
-	Err    string `json:"error"`
+	Status interface{} `json:"status"`
+	Err    string      `json:"error"`
 
 	ErrTypeCode int    `json:"error_type_code"`
 	ErrMsg      string `json:"error_msg"`

--- a/bitriseio/keystore.go
+++ b/bitriseio/keystore.go
@@ -14,11 +14,9 @@ import (
 
 // UploadKeystoreParams ...
 type UploadKeystoreParams struct {
-	Alias          string `json:"alias,omitempty"`
-	Password       string `json:"password,omitempty"`
-	KeyPassword    string `json:"private_key_password,omitempty"`
-	UploadFileName string `json:"upload_file_name,omitempty"`
-	UploadFileSize int64  `json:"upload_file_size,omitempty"`
+	Alias       string `json:"alias"`
+	Password    string `json:"password"`
+	KeyPassword string `json:"private_key_password"`
 }
 
 // UploadKeystoreURL ...
@@ -51,11 +49,17 @@ func (s *AppService) UploadKeystore(pth string, params UploadKeystoreParams) err
 	name := filepath.Base(f.Name())
 	name = strings.TrimSuffix(name, filepath.Ext(name))
 
-	params.UploadFileSize = i.Size()
-	params.UploadFileName = name
+	type Params struct {
+		UploadKeystoreParams
+		UploadFileName string `json:"upload_file_name"`
+		UploadFileSize int64  `json:"upload_file_size"`
+	}
+	p := Params{UploadKeystoreParams: params}
+	p.UploadFileSize = i.Size()
+	p.UploadFileName = name
 
 	// register keystore
-	req, err := s.client.newRequest(http.MethodPost, UploadKeystoreURL(s.Slug), params)
+	req, err := s.client.newRequest(http.MethodPost, UploadKeystoreURL(s.Slug), p)
 	if err != nil {
 		return err
 	}

--- a/bitriseio/register.go
+++ b/bitriseio/register.go
@@ -9,22 +9,28 @@ const RegisterURL = AppsServiceURL + "register"
 
 // RegisterParams ...
 type RegisterParams struct {
-	GitOwner    string `json:"git_owner,omitempty"`
-	GitRepoSlug string `json:"git_repo_slug,omitempty"`
-	IsPublic    bool   `json:"is_public,omitempty"`
-	Provider    string `json:"provider,omitempty"`
-	RepoURL     string `json:"repo_url,omitempty"`
-	Type        string `json:"type,omitempty"`
+	GitOwner    string `json:"git_owner"`
+	GitRepoSlug string `json:"git_repo_slug"`
+	IsPublic    bool   `json:"is_public"`
+	Provider    string `json:"provider"`
+	RepoURL     string `json:"repo_url"`
 }
 
 // Register ...
 func (s *AppsService) Register(params RegisterParams) (*AppService, error) {
-	req, err := s.client.newRequest(http.MethodPost, RegisterURL, params)
+	type Params struct {
+		RegisterParams
+		Type string `json:"type"`
+	}
+	p := Params{RegisterParams: params}
+	p.Type = "git"
+
+	req, err := s.client.newRequest(http.MethodPost, RegisterURL, p)
 	if err != nil {
 		return nil, err
 	}
 	type RegisterResponse struct {
-		Slug string `json:"slug,omitempty"`
+		Slug string `json:"slug"`
 	}
 	var resp RegisterResponse
 	if err := s.client.do(req, &resp); err != nil {

--- a/bitriseio/sshkey.go
+++ b/bitriseio/sshkey.go
@@ -7,9 +7,9 @@ import (
 
 // RegisterSSHKeyParams ...
 type RegisterSSHKeyParams struct {
-	AuthSSHPrivateKey                string `json:"auth_ssh_private_key,omitempty"`
+	AuthSSHPrivateKey                string `json:"auth_ssh_private_key"`
 	AuthSSHPublicKey                 string `json:"auth_ssh_public_key,omitempty"`
-	IsRegisterKeyIntoProviderService bool   `json:"is_register_key_into_provider_service,omitempty"`
+	IsRegisterKeyIntoProviderService bool   `json:"is_register_key_into_provider_service"`
 }
 
 // RegisterSSHKeyURL ...

--- a/phases/account.go
+++ b/phases/account.go
@@ -90,10 +90,12 @@ func Account(apiToken string) (string, error) {
 			log.Errorf("error reading choice from stdin: %s", err)
 		} else if !isValid(choice, len(options)) {
 			log.Errorf("invalid choice")
-		} else {
-			return options[choice-1]["slug"].(string), nil
+		} else if choice == 1 {
+			// own user selected
+			return "", nil
 		}
-	}
 
-	return "", fmt.Errorf("invalid execution branch: unknown error")
+		// organization selected
+		return options[choice-1]["slug"].(string), nil
+	}
 }

--- a/phases/bitrise_yml.go
+++ b/phases/bitrise_yml.go
@@ -101,7 +101,7 @@ func selectBitriseYMLFile(inputReader io.Reader) (models.BitriseDataModel, bool,
 		if err != nil {
 			log.Warnf("Failed to parse bitrise.yml, error: %s", err)
 			continue
-		} else if warnings != nil {
+		} else if len(warnings) > 0 {
 			log.Warnf("Parsed bitrise.yml, with warnings:")
 			for _, warning := range warnings {
 				log.Warnf(warning)

--- a/phases/codesign.go
+++ b/phases/codesign.go
@@ -43,7 +43,7 @@ func getPlatform(projectType string) string {
 
 // AutoCodesign ...
 func AutoCodesign(projectType string) (CodesignResult, error) {
-	log.Donef("Found %s based project", projectType)
+	log.Donef("Project type: %s", projectType)
 	fmt.Println()
 
 	var result CodesignResult

--- a/phases/private_key.go
+++ b/phases/private_key.go
@@ -19,7 +19,7 @@ func generateSSHKey() (string, string, error) {
 
 	keyFilePath := filepath.Join(tempDir, "key")
 
-	cmd := command.New("ssh-keygen", "-q", "-t", "rsa", "-b", "4096", "-C", "builds@bitrise.io", "-P", "", "-f", keyFilePath)
+	cmd := command.New("ssh-keygen", "-q", "-t", "rsa", "-b", "2048", "-C", "builds@bitrise.io", "-P", "", "-f", keyFilePath, "-m", "PEM")
 	if out, err := cmd.RunAndReturnTrimmedCombinedOutput(); err != nil {
 		return "", "", errors.Wrap(fmt.Errorf("failed to run command: %s, error: %s", cmd.PrintableCommandArgs(), err), out)
 	}

--- a/phases/progress.go
+++ b/phases/progress.go
@@ -4,15 +4,14 @@ import "github.com/bitrise-io/bitrise/models"
 
 // Progress ...
 type Progress struct {
-	Account string
-	Public  bool
+	OrganizationSlug string
+	Public           bool
 
 	Repo         string
 	RepoURL      string
 	RepoProvider string
 	RepoOwner    string
 	RepoSlug     string
-	RepoType     string
 
 	SSHPrivateKeyPth string
 	SSHPublicKeyPth  string

--- a/phases/repo.go
+++ b/phases/repo.go
@@ -17,7 +17,6 @@ type RepoDetails struct {
 	Provider string
 	Owner    string
 	Slug     string
-	RepoType string
 }
 
 type urlParts struct {
@@ -90,7 +89,6 @@ func Repo(isPublic bool) (RepoDetails, error) {
 	}
 
 	provider := getProvider(out)
-	repoType := "git"
 
 	parts := parseURL(out)
 	var url string
@@ -105,13 +103,11 @@ func Repo(isPublic bool) (RepoDetails, error) {
 	log.Donef("- provider: %s", provider)
 	log.Donef("- owner: %s", parts.owner)
 	log.Donef("- slug: %s", parts.slug)
-	log.Donef("- repo type: %s", repoType)
 
 	return RepoDetails{
 		url,
 		provider,
 		parts.owner,
 		parts.slug,
-		repoType,
 	}, nil
 }

--- a/phases/stack.go
+++ b/phases/stack.go
@@ -13,8 +13,8 @@ var defaultStacks = map[string]string{
 	"ionic":        "osx-vs4mac-stable",
 	"flutter":      "osx-vs4mac-stable",
 	"android":      "linux-docker-android",
-	"macos":        "osx-xcode-10.0",
-	"ios":          "osx-xcode-10.0",
+	"macos":        "osx-xcode-10.0.x",
+	"ios":          "osx-xcode-10.0.x",
 }
 
 var optionsStacks = []string{

--- a/phases/webhook.go
+++ b/phases/webhook.go
@@ -7,7 +7,10 @@ func AddWebhook() (bool, error) {
 	var registerWebhook bool
 
 	log.Printf("WEBHOOK SETUP")
-	log.Printf("To have Bitrise automatically start a build every time you push code into your repository you can set up a webhook at your code hosting service which will automatically trigger a build on Bitrise with the code you push to your repository.")
+	log.Printf(`To let Bitrise automatically start a build every time you:
+- push code
+- open a pull request
+into your repository, you can set up a webhook at your code hosting service.`)
 	log.Printf("We can automatically register a Webhook for you if you have administrator rights for this repository.")
 
 	const (


### PR DESCRIPTION
- API endpoint params modified in the way that only settable fields are exposed
- omitempty removed from API params, as it would hide false bool fields which cases API issues
- ErrorResponse.Status is an interface, since in case of some API issues it holds string value, while in other cases int value
- Proper config selection introduced for the finish endpoint
- cmdFlagAccount renamed to cmdFlagOrganisation as it can store only an organization id
- verbose flag introduced
- fixed an account selection issue
- fixed a bitrise.yml parse warning printing
- project type logging fix as in case of other project type it looked really strange
- ssh private key creation updated since the API accepts only ssh key with byte length 2048 and in PEM format
- RepoType progress field removed as it's default value is defined by the API call, Account renamed to OrganizationSlug as it can store only an org id
- webhook question message updated