### PR TITLE
Tool-380 maintenance test check stacks

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -32,6 +32,12 @@ workflows:
             docker build --tag bitrise-add-new-project-test docker_ci_linux/
             docker run --rm bitrise-add-new-project-test
 
+  maintenance:
+    steps:
+    - go-test:
+        inputs:
+          - packages: "./maintenance"
+  
   dep-update:
     steps:
     - script:

--- a/config/stack.go
+++ b/config/stack.go
@@ -4,20 +4,22 @@ package config
 // known by the BANP tool. The slice should
 // be updated whenever the list of supported
 // stacks are modified.
-var Stacks = []string{
-	"linux-docker-android-lts",
-	"linux-docker-android",
-	"osx-vs4mac-beta",
-	"osx-vs4mac-previous-stable",
-	"osx-vs4mac-stable",
-	"osx-xcode-10.0.x",
-	"osx-xcode-10.1.x",
-	"osx-xcode-10.2.x",
-	"osx-xcode-10.3.x",
-	"osx-xcode-11.0.x",
-	"osx-xcode-11.1.x",
-	"osx-xcode-11.2.x",
-	"osx-xcode-8.3.x",
-	"osx-xcode-9.4.x",
-	"osx-xcode-edge",
+func Stacks() []string {
+	return []string{
+		"linux-docker-android-lts",
+		"linux-docker-android",
+		"osx-vs4mac-beta",
+		"osx-vs4mac-previous-stable",
+		"osx-vs4mac-stable",
+		"osx-xcode-10.0.x",
+		"osx-xcode-10.1.x",
+		"osx-xcode-10.2.x",
+		"osx-xcode-10.3.x",
+		"osx-xcode-11.0.x",
+		"osx-xcode-11.1.x",
+		"osx-xcode-11.2.x",
+		"osx-xcode-8.3.x",
+		"osx-xcode-9.4.x",
+		"osx-xcode-edge",
+	}
 }

--- a/config/stack.go
+++ b/config/stack.go
@@ -1,0 +1,19 @@
+package config
+
+var Stacks = []string{
+	"linux-docker-android-lts",
+	"linux-docker-android",
+	"osx-vs4mac-beta",
+	"osx-vs4mac-previous-stable",
+	"osx-vs4mac-stable",
+	"osx-xcode-10.0.x",
+	"osx-xcode-10.1.x",
+	"osx-xcode-10.2.x",
+	"osx-xcode-10.3.x",
+	"osx-xcode-11.0.x",
+	"osx-xcode-11.1.x",
+	"osx-xcode-11.2.x",
+	"osx-xcode-8.3.x",
+	"osx-xcode-9.4.x",
+	"osx-xcode-edge",
+}

--- a/config/stack.go
+++ b/config/stack.go
@@ -1,5 +1,9 @@
 package config
 
+// Stacks contains the current stack IDs
+// known by the BANP tool. The slice should
+// be updated whenever the list of supported
+// stacks are modified.
 var Stacks = []string{
 	"linux-docker-android-lts",
 	"linux-docker-android",

--- a/maintenance/maintenance_test.go
+++ b/maintenance/maintenance_test.go
@@ -21,7 +21,11 @@ func TestStackChange(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error getting current stack list from GitHub: %s", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Fatalf("Error closing response body")
+		}
+	}()
 
 	bytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/maintenance/maintenance_test.go
+++ b/maintenance/maintenance_test.go
@@ -1,0 +1,48 @@
+package maintenance
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/bitrise-io/bitrise-add-new-project/config"
+	"github.com/bitrise-io/go-utils/sliceutil"
+)
+
+type ResponseBody []DirectoryEntry
+type DirectoryEntry struct {
+	Name string `json:"name"`
+}
+
+func TestStackChange(t *testing.T) {
+	resp, err := http.Get("https://api.github.com/repos/bitrise-io/bitrise.io/contents/system_reports")
+	if err != nil {
+
+	}
+	defer resp.Body.Close()
+
+	bytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+
+	}
+
+	var rb ResponseBody
+	if err := json.Unmarshal(bytes, &rb); err != nil {
+
+	}
+
+	changed := false
+	for _, e := range rb {
+		trimmed := strings.TrimSuffix(e.Name, ".log")
+		if !sliceutil.IsStringInSlice(trimmed, config.Stacks) {
+			changed = true
+		}
+	}
+
+	if changed {
+		t.Logf("Stack list changed.")
+	}
+
+}

--- a/maintenance/maintenance_test.go
+++ b/maintenance/maintenance_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -25,7 +26,7 @@ func (reports systemReports) Stacks() (s []string) {
 }
 
 func TestStackChange(t *testing.T) {
-	resp, err := http.Get("https://api.github.com/repos/bitrise-io/bitrise.io/contents/system_reports")
+	resp, err := http.Get("https://api.github.com/repos/bitrise-io/bitrise.io/contents/system_reports?access_token=" + os.Getenv("GIT_BOT_USER_ACCESS_TOKEN"))
 	if err != nil {
 		t.Fatalf("Error getting current stack list from GitHub: %s", err)
 	}

--- a/maintenance/maintenance_test.go
+++ b/maintenance/maintenance_test.go
@@ -19,18 +19,18 @@ type DirectoryEntry struct {
 func TestStackChange(t *testing.T) {
 	resp, err := http.Get("https://api.github.com/repos/bitrise-io/bitrise.io/contents/system_reports")
 	if err != nil {
-
+		t.Fatalf("Error getting current stack list from GitHub: %s", err)
 	}
 	defer resp.Body.Close()
 
 	bytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-
+		t.Fatalf("Error reading stack info from GitHub response: %s", err)
 	}
 
 	var rb ResponseBody
 	if err := json.Unmarshal(bytes, &rb); err != nil {
-
+		t.Fatalf("Error unmarshalling stack data from string (%s): %s", bytes, err)
 	}
 
 	changed := false
@@ -42,7 +42,7 @@ func TestStackChange(t *testing.T) {
 	}
 
 	if changed {
-		t.Logf("Stack list changed.")
+		t.Fatalf("Stack list changed.")
 	}
 
 }

--- a/maintenance/maintenance_test.go
+++ b/maintenance/maintenance_test.go
@@ -37,8 +37,8 @@ func TestStackChange(t *testing.T) {
 		t.Fatalf("Stack list changed")
 	}
 
-	for _, e := range rb {
-		trimmed := strings.TrimSuffix(e.Name, ".log")
+	for _, de := range rb {
+		trimmed := strings.TrimSuffix(de.Name, ".log")
 		if !sliceutil.IsStringInSlice(trimmed, config.Stacks) {
 			t.Fatalf("Stack list changed")
 		}

--- a/maintenance/maintenance_test.go
+++ b/maintenance/maintenance_test.go
@@ -33,16 +33,15 @@ func TestStackChange(t *testing.T) {
 		t.Fatalf("Error unmarshalling stack data from string (%s): %s", bytes, err)
 	}
 
-	changed := false
+	if len(config.Stacks) != len(rb) {
+		t.Fatalf("Stack list changed")
+	}
+
 	for _, e := range rb {
 		trimmed := strings.TrimSuffix(e.Name, ".log")
 		if !sliceutil.IsStringInSlice(trimmed, config.Stacks) {
-			changed = true
+			t.Fatalf("Stack list changed")
 		}
-	}
-
-	if changed {
-		t.Fatalf("Stack list changed.")
 	}
 
 }

--- a/phases/stack.go
+++ b/phases/stack.go
@@ -90,4 +90,6 @@ func Stack(projectType string) (string, error) {
 
 		return stack, nil
 	}
+
+	return "", fmt.Errorf("invalid state")
 }

--- a/phases/stack.go
+++ b/phases/stack.go
@@ -20,8 +20,6 @@ var defaultStacks = map[string]string{
 	"ios":          "osx-xcode-10.2.x",
 }
 
-var optionsStacks = config.Stacks
-
 // Stack returns the selected stack for the project or an error
 // if something went wrong during stack autodetection.
 func Stack(projectType string) (string, error) {
@@ -35,7 +33,7 @@ func Stack(projectType string) (string, error) {
 
 		prompt := promptui.Select{
 			Label: "Please choose from the available stacks",
-			Items: optionsStacks,
+			Items: config.Stacks(),
 			Templates: &promptui.SelectTemplates{
 				Selected: "Stack: {{ . | green }}",
 			},
@@ -80,7 +78,7 @@ func Stack(projectType string) (string, error) {
 
 		stackPrompt := promptui.Select{
 			Label: "Choose stack",
-			Items: optionsStacks,
+			Items: config.Stacks(),
 			Templates: &promptui.SelectTemplates{
 				Selected: "Stack: {{ . | green }}",
 			},
@@ -92,6 +90,4 @@ func Stack(projectType string) (string, error) {
 
 		return stack, nil
 	}
-
-	return "", fmt.Errorf("invalid state")
 }

--- a/phases/stack.go
+++ b/phases/stack.go
@@ -3,6 +3,7 @@ package phases
 import (
 	"fmt"
 
+	"github.com/bitrise-io/bitrise-add-new-project/config"
 	"github.com/bitrise-io/go-utils/colorstring"
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/manifoldco/promptui"
@@ -19,21 +20,7 @@ var defaultStacks = map[string]string{
 	"ios":          "osx-xcode-10.2.x",
 }
 
-var optionsStacks = []string{
-	"linux-docker-android-lts",
-	"linux-docker-android",
-	"osx-vs4mac-beta",
-	"osx-vs4mac-previous-stable",
-	"osx-vs4mac-stable",
-	"osx-xamarin-stable",
-	"osx-xcode-10.0.x",
-	"osx-xcode-10.1.x",
-	"osx-xcode-10.2.x",
-	"osx-xcode-8.3.x",
-	"osx-xcode-9.2.x",
-	"osx-xcode-9.4.x",
-	"osx-xcode-edge",
-}
+var optionsStacks = config.Stacks
 
 // Stack returns the selected stack for the project or an error
 // if something went wrong during stack autodetection.


### PR DESCRIPTION
A `maintenance` workflow has been created to facilitate the running of maintenance tests checking for any changes in the supported stacks.