### PR TITLE
Test release process in CI, revert using Go 1.17

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -4,7 +4,7 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 workflows:
   test:
     after_run:
-    - _test_binary_build
+    - _test-binary-build
     steps:
     - go-list: { }
     - golint: { }

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -3,6 +3,8 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 workflows:
   test:
+    after_run:
+    - _test_binary_build
     steps:
     - go-list: { }
     - golint: { }
@@ -48,7 +50,7 @@ workflows:
             set -ex
             goreleaser release
 
-  test-binary-build:
+  _test-binary-build:
     description: Tests the release build process by creating a snapshot release (without publishing)
     steps:
     - script:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bitrise-io/bitrise-add-new-project
 
-go 1.18
+go 1.17
 
 require (
 	github.com/bitrise-io/bitrise v0.0.0-20210623145422-513e39485248

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bitrise-io/bitrise-add-new-project
 
-go 1.19
+go 1.18
 
 require (
 	github.com/bitrise-io/bitrise v0.0.0-20210623145422-513e39485248


### PR DESCRIPTION
### Context

The release workflow started failing after #70 because the Go version was upgraded in the `go.mod` file and the build VM has a lower Go version installed at the moment.

```
error=hook failed: go mod tidy: exit status 1; output: go: go.mod file indicates go 1.19, but maximum version supported by tidy is 1.18
```

### Changes

- Revert to using Go 1.18
- Execute Goreleaser part of the PR pipeline to catch a similar error in the future