### PR TITLE
Use custom User Agent

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,6 +1,11 @@
 format_version: "7"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
+app:
+  envs:
+  # the field 'replacements' was removed in 1.19
+  # https://goreleaser.com/deprecations/#archivesreplacements
+  - GORELEASER_VERSION: "v1.18.2"
 workflows:
   test:
     after_run:
@@ -45,7 +50,7 @@ workflows:
         - content: |
             #!/usr/bin/env bash
             set -ex
-            curl -sfL https://goreleaser.com/static/run | bash -s -- release
+            curl -sfL https://goreleaser.com/static/run | VERSION=$GORELEASER_VERSION bash -s -- release
 
   _test-binary-build:
     description: Tests the release build process by creating a snapshot release (without publishing)
@@ -56,5 +61,5 @@ workflows:
         - content: |
             #!/usr/bin/env bash
             set -ex
-            curl -sfL https://goreleaser.com/static/run | bash -s -- release --snapshot --rm-dist
+            curl -sfL https://goreleaser.com/static/run | VERSION=$GORELEASER_VERSION bash -s -- release --snapshot --rm-dist
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -38,8 +38,6 @@ workflows:
     description: Creates Linux and Darwin binaries, then publishes a GitHub release
     envs:
     - GITHUB_TOKEN: $GIT_BOT_USER_ACCESS_TOKEN # Goreleaser expects this env var
-    before_run:
-    - _install-goreleaser
     steps:
     - script:
         title: Goreleaser (create binaries + publish to GH)
@@ -47,12 +45,10 @@ workflows:
         - content: |
             #!/usr/bin/env bash
             set -ex
-            goreleaser release
+            curl -sfL https://goreleaser.com/static/run | bash -s -- release
 
   _test-binary-build:
     description: Tests the release build process by creating a snapshot release (without publishing)
-    before_run:
-    - _install-goreleaser
     steps:
     - script:
         title: Goreleaser (create snapshot binaries)
@@ -60,14 +56,5 @@ workflows:
         - content: |
             #!/usr/bin/env bash
             set -ex
-            goreleaser release --snapshot --rm-dist
+            curl -sfL https://goreleaser.com/static/run | bash -s -- release --snapshot --rm-dist
 
-  _install-goreleaser:
-    steps:
-    - script:
-        title: Install goreleaser
-        inputs:
-        - content: |
-            #!/usr/bin/env bash
-            set -ex
-            go install github.com/goreleaser/goreleaser@latest

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -19,7 +19,7 @@ workflows:
             #!/bin/env bash
             env GOOS=linux go build -v github.com/bitrise-io/bitrise-add-new-project
             cp bitrise-add-new-project ./docker_linux_interactive
-            
+
             cd docker_linux_interactive
             docker build --tag bitrise-add-new-project-test-interactive .
             docker run --rm -ti bitrise-add-new-project-test-interactive
@@ -38,12 +38,11 @@ workflows:
     description: Creates Linux and Darwin binaries, then publishes a GitHub release
     envs:
     - GITHUB_TOKEN: $GIT_BOT_USER_ACCESS_TOKEN # Goreleaser expects this env var
+    before_run:
+    - _install-goreleaser
     steps:
     - script:
         title: Goreleaser (create binaries + publish to GH)
-        deps:
-          brew:
-          - name: goreleaser
         inputs:
         - content: |
             #!/usr/bin/env bash
@@ -52,14 +51,23 @@ workflows:
 
   _test-binary-build:
     description: Tests the release build process by creating a snapshot release (without publishing)
+    before_run:
+    - _install-goreleaser
     steps:
     - script:
         title: Goreleaser (create snapshot binaries)
-        deps:
-          brew:
-          - name: goreleaser
         inputs:
         - content: |
             #!/usr/bin/env bash
             set -ex
             goreleaser release --snapshot --rm-dist
+
+  _install-goreleaser:
+    steps:
+    - script:
+        title: Install goreleaser
+        inputs:
+        - content: |
+            #!/usr/bin/env bash
+            set -ex
+            go install github.com/goreleaser/goreleaser@latest

--- a/bitriseio/client.go
+++ b/bitriseio/client.go
@@ -73,6 +73,7 @@ func (c *Client) newRequest(method, urlStr string, body interface{}) (*http.Requ
 	}
 
 	req.Header.Set("Authorization", c.token)
+	req.Header.Set("User-Agent", "bitrise-add-new-project/0.14")
 
 	return req, nil
 }


### PR DESCRIPTION
so we can differentiate between Website and CLI Add New App flow types.

(I understand the version number ideally should be dynamic, but it doesn't seem to worth the effort now, it's just there to respect the User Agent format, but we wouldn't use that for now.)

On Linux, goreleaser wasn't installed properly, I changed to the [suggested invocation mode in CI environment](https://goreleaser.com/install/#bash-script), and pinned to the last working version.